### PR TITLE
Add two Debian packages to enable Docker build

### DIFF
--- a/misc/docker/seqrepo.df
+++ b/misc/docker/seqrepo.df
@@ -19,7 +19,9 @@ RUN apt update && apt install -y \
     curl \
     python3-pip \
     rsync \
-    zlib1g-dev
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev
 
 RUN pip3 install --upgrade setuptools pip
 


### PR DESCRIPTION
The most recent biopython and pysam libraries require two more packages to build.