### PR TITLE
 #45: Improve coverage of init function in cli module and fix key in formatted exception message

### DIFF
--- a/biocommons/seqrepo/cli.py
+++ b/biocommons/seqrepo/cli.py
@@ -310,7 +310,7 @@ def fetch_load(opts):
 def init(opts):
     seqrepo_dir = os.path.join(opts.root_directory, opts.instance_name)
     if os.path.exists(seqrepo_dir) and len(os.listdir(seqrepo_dir)) > 0:
-        raise IOError("{seqrepo_dir} exists and is not empty".format(opts=opts))
+        raise IOError("{seqrepo_dir} exists and is not empty".format(seqrepo_dir=seqrepo_dir))
     sr = SeqRepo(seqrepo_dir, writeable=True)    # flake8: noqa
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,12 @@ def test_00_init(opts):
     init(opts)
     assert os.path.exists(opts.root_directory)
 
+    with pytest.raises(IOError) as excinfo:
+        init(opts)
+
+    seqrepo_dir = os.path.join(opts.root_directory, opts.instance_name)
+    assert str(excinfo.value) == "{seqrepo_dir} exists and is not empty".format(seqrepo_dir=seqrepo_dir)
+
 
 def test_20_load(opts):
     load(opts)


### PR DESCRIPTION
Attempting to raise the original `IOError` instead raised a `KeyError` as the key in the formatted string was not provided. This fix also