### PR TITLE
Changed 3.6 to 3 in python.pythonPath in .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "python.formatting.provider": "yapf",
     "editor.formatOnSave": true,
     "python.venvPath": "${workspaceFolder}/venv/",
-    "python.pythonPath": "${workspaceFolder}/venv/3.6/bin/python",
+    "python.pythonPath": "${workspaceFolder}/venv/3/bin/python",
     "python.unitTest.unittestEnabled": false,
     "python.unitTest.nosetestsEnabled": false,
     "python.unitTest.pyTestEnabled": true,


### PR DESCRIPTION
I think this needs to be updated, since the name of the virtual environment was changed in the Makefile. 

However, even with this change, when using VScode, I still can't see the virtual environment as an option when I look at the list using: command+shift+p "Python: Select Interpreter".