### PR TITLE
Use custom commonpath implementation on Python 3.4

### DIFF
--- a/biocommons/seqrepo/py2compat/__init__.py
+++ b/biocommons/seqrepo/py2compat/__init__.py
@@ -3,12 +3,24 @@ import io
 
 import six
 
+try:
+    from functools import lru_cache    # Python >= 3.2
+except ImportError:
+    from ._lru_cache import lru_cache
+
+try:
+    from shutil import which    # Python >= 3.3
+except ImportError:
+    from ._which import which
+
+try:
+    from os.path import commonpath    # Python >= 3.5
+except ImportError:
+    from ._commonpath import commonpath
+
 if six.PY2:    # pragma: no cover
 
-    from ._lru_cache import lru_cache
     from ._makedirs import makedirs, FileExistsError
-    from ._commonpath import commonpath
-    from ._which import which
 
     def gzip_open_encoded(file, encoding=None):
         return io.TextIOWrapper(io.BufferedReader(gzip.open(file)), encoding="utf8")
@@ -16,10 +28,6 @@ if six.PY2:    # pragma: no cover
 else:    # pragma: no cover
 
     from os import makedirs     # flake8: noqa
-    from os.path import commonpath
-    from functools import lru_cache
-    from shutil import which   # >= Python 3.3
-
     FileExistsError = FileExistsError
 
     def gzip_open_encoded(file, encoding=None):


### PR DESCRIPTION
The latest stable version of RHEL/CentOS is still on Python 3.4, which is preventing us from using seqrepo on our servers. This commit makes the Python compatibility code more generic so that seqrepo can work on Python 3.4 and earlier.