### PR TITLE
FIx documentation URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ XM, and XP) consumes approximately 8GB.  The minimum marginal size for
 additional snapshots is approximately 2GB (for the sqlite database,
 which is not hardlinked).
 
-For more information, see `<doc/design.rst>`__.
+For more information, see `<docs/design.rst>`__.
 
 
 
@@ -143,8 +143,8 @@ On Ubuntu 16.04::
   ATACAGTGTGGTTCAAAAAAATTTGTTGTATCAAGGTAAAATAATAGCCTGAATATAATTAAGATAGTCTGTGTATACATCGATGAAAACATTGCCAATA
 
 
-See `Installation <doc/installation.rst>`__ and `Mirroring
-<doc/mirror.rst>`__ for more information.
+See `Installation <docs/installation.rst>`__ and `Mirroring
+<docs/mirror.rst>`__ for more information.
 
 
 Developing

--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,10 @@ Features
 Deployments Scenarios
 !!!!!!!!!!!!!!!!!!!!!
 * Local read-only archive, mirrored from public site,
-  accessed via Python API (see `Mirroring documentation <doc/mirror.rst>`__)
+  accessed via Python API (see `Mirroring documentation <docs/mirror.rst>`__)
 * Local read-write archive, maintained with command
   line utility and/or API (see `Command Line Interface documentation
-  <doc/cli.rst>`__).
+  <docs/cli.rst>`__).
 * Docker-based data-only container that may be linked to application container.
 * Planned: Docker image that provides REST interface for local or remote access
 


### PR DESCRIPTION
In the main README the documentation urls point to `/doc/` but should reference `/docs/`.