### PR TITLE
build: fix dynamic dependencies for newer setuptools versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,18 +15,28 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dynamic = ["version"]
+dynamic = ["version", "optional-dependencies"]
+dependencies = [
+    "bioutils > 0.4",
+    "coloredlogs",
+    "ipython",
+    "pysam",
+    "requests",
+    "requests_html",
+    "six",
+    "tqdm",
+    "yoyo-migrations"
+]
 
 [project.urls]
 "Homepage" = "https://github.com/biocommons/biocommons.seqrepo"
 "Bug Tracker" = "https://github.com/biocommons/biocommons.seqrepo/issues"
 
-
 [build-system]
 requires = [
-	 "setuptools >= 65.3",
-   	 "setuptools_scm[toml] ~= 7.0"
-	 ]
+    "setuptools >= 69.0.2",
+    "setuptools_scm[toml] >= 8.0"
+]
 build-backend = "setuptools.build_meta"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,12 @@
+[metadata]
+name = biocommons.seqrepo
+
 [options]
 include_package_data = True
 packages = find_namespace:
 package_dir =
     = src
 zip_safe = True
-
-install_requires =
-    bioutils>0.4
-    coloredlogs
-    ipython
-    pysam
-    requests
-    requests_html
-    six
-    tqdm
-    yoyo-migrations
 
 [options.extras_require]
 dev =
@@ -29,7 +21,7 @@ dev =
     setuptools_scm
     vcrpy
     wheel
-docs = 
+docs =
     mkdocs
 
 [options.entry_points]


### PR DESCRIPTION
1-for-1 mirroring of @andreasprlic PR on HGVS: https://github.com/biocommons/hgvs/pull/713

FWIW, more and more Python tools support configuration in `pyproject.toml`, might be nice to consolidate the rest of the setuptools configs in `setup.cfg` + some of the other files (`pytest.ini`, etc) 