### PR TITLE
style: format with Ruff

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,9 +33,9 @@ jobs:
       run: |
         isort --check src
 
-    - name: Format check with black
+    - name: Format check with ruff
       run: |
-        black --check src
+        ruff format --check src
 
     - name: Security check with bandit
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,8 @@ repos:
        entry: isort
        language: system
        types: [python]
-    -  id: black
-       name: black
-       entry: black
-       language: system
-       types: [python]
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.4
+  hooks:
+    - id: ruff-format
+      args: [ --check ]

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build: %:
 cqa:
 	flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
 	isort --profile black --check src
-	black --check src
+	ruff format --check src tests
 	bandit -ll -r src
 
 #=> test: execute tests
@@ -97,7 +97,7 @@ cqa:
 	flake8 src --show-source --statistics
 	pyright
 	isort --check src --profile black
-	black --check src
+	ruff format --check src
 	bandit -ll -r src
 
 #=> reformat: reformat code
@@ -108,13 +108,13 @@ reformat:
 ############################################################################
 #= UTILITY TARGETS
 
-#=> reformat: reformat code with yapf and commit
+#=> reformat: reformat code and commit
 .PHONY: reformat
 reformat:
 	@if ! git diff --cached --exit-code >/dev/null; then echo "Repository not clean" 1>&2; exit 1; fi
-	black src tests
+	ruff src tests
 	isort src tests
-	git commit -a -m "reformatted with black and isort"
+	git commit -a -m "reformatted with ruff and isort"
 
 #=> rename: rename files and substitute content for new repo name
 .PHONY: rename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,5 +132,5 @@ disable = "R0913"
 max-line-length = 100
 
 [tool.ruff]
-src = ["src", "test"]
+src = ["src", "tests"]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "bandit ~= 1.7",
-    "black ~= 22.3",
     "build ~= 0.8",
     "flake8 ~= 4.0",
     "ipython ~= 8.4",
@@ -43,6 +42,7 @@ dev = [
     "pytest ~= 7.1",
     "pyright~=1.1",
     "requests_html ~= 0.10",
+    "ruff == 0.4.4",
     "tox ~= 3.25",
     "vcrpy",
 ]
@@ -117,9 +117,6 @@ exclude_lines = [
     "if __name__ == .__main__.:",
 ]
 
-[tool.black]
-line-length = 100
-
 [tool.isort]
 profile = "black"
 src_paths = ["src", "tests"]
@@ -134,3 +131,7 @@ disable = "R0913"
 
 [tool.pylint.format]
 max-line-length = 100
+
+[tool.ruff]
+src = ["src", "test"]
+line-length = 100

--- a/src/biocommons/seqrepo/cli.py
+++ b/src/biocommons/seqrepo/cli.py
@@ -10,6 +10,7 @@ Try::
   $ seqrepo --help
 
 """
+
 import argparse
 import datetime
 import gzip
@@ -524,7 +525,10 @@ def load(opts: argparse.Namespace) -> None:
             fh = io.open(fn, mode="rt", encoding="ascii")
         _logger.info("Opened " + fn)
         seq_bar = tqdm.tqdm(
-            FastaIter(fh), unit=" seqs", disable=disable_bar, leave=False  # type: ignore noqa: E501
+            FastaIter(fh),  # type: ignore
+            unit=" seqs",
+            disable=disable_bar,
+            leave=False,  # type: ignore noqa: E501
         )
         for defline, seq in seq_bar:  # type: ignore
             n_seqs_seen += 1

--- a/src/biocommons/seqrepo/cli.py
+++ b/src/biocommons/seqrepo/cli.py
@@ -528,7 +528,7 @@ def load(opts: argparse.Namespace) -> None:
             FastaIter(fh),  # type: ignore
             unit=" seqs",
             disable=disable_bar,
-            leave=False,  # type: ignore noqa: E501
+            leave=False,
         )
         for defline, seq in seq_bar:  # type: ignore
             n_seqs_seen += 1

--- a/src/biocommons/seqrepo/fastadir/fabgz.py
+++ b/src/biocommons/seqrepo/fastadir/fabgz.py
@@ -5,6 +5,7 @@ A file may not currently be opened for reading and writing at the same time
 Files must be named as .fa.bgz to be recognized as blocked gzip compressed
 
 """
+
 import io
 import logging
 import os

--- a/src/biocommons/seqrepo/fastadir/fastadir.py
+++ b/src/biocommons/seqrepo/fastadir/fastadir.py
@@ -81,9 +81,7 @@ class FastaDir(BaseReader, BaseWriter):
         if schema_version != expected_schema_version:
             raise RuntimeError(
                 """Upgrade required: Database schema
-            version is {} and code expects {}""".format(
-                    schema_version, expected_schema_version
-                )
+            version is {} and code expects {}""".format(schema_version, expected_schema_version)
             )
 
         if fd_cache_size == 0:
@@ -142,9 +140,7 @@ class FastaDir(BaseReader, BaseWriter):
         if self._writing and self._writing["relpath"] == rec["relpath"]:
             _logger.warning(
                 """Fetching from file opened for writing;
-            closing first ({})""".format(
-                    rec["relpath"]
-                )
+            closing first ({})""".format(rec["relpath"])
             )
             self.commit()
 

--- a/src/biocommons/seqrepo/seqaliasdb/seqaliasdb.py
+++ b/src/biocommons/seqrepo/seqaliasdb/seqaliasdb.py
@@ -53,8 +53,9 @@ class SeqAliasDB(object):
         # if we're not at the expected schema version for this code, bail
         if schema_version != expected_schema_version:  # pragma: no cover
             raise RuntimeError(
-                "Upgrade required: Database schema"
-                "version is {} and code expects {}".format(schema_version, expected_schema_version)
+                "Upgrade required: Database schema" "version is {} and code expects {}".format(
+                    schema_version, expected_schema_version
+                )
             )
 
     # ############################################################################


### PR DESCRIPTION
Per an earlier discussion, this implements just the format half of `ruff`, removing `black`. Because `ruff` handles things like `isort` on the lint side, this PR doesn't address that yet.