### PR TITLE
refactor: resolve timezone-related python 3.12 deprecations

### DIFF
--- a/src/biocommons/seqrepo/fastadir/fastadir.py
+++ b/src/biocommons/seqrepo/fastadir/fastadir.py
@@ -194,7 +194,7 @@ class FastaDir(BaseReader, BaseWriter):
         #       <------ dir_ ----->
         #       <----------- path ----------->
         if self._writing is None:
-            reldir = datetime.datetime.utcnow().strftime("%Y/%m%d/%H%M")
+            reldir = datetime.datetime.now(datetime.UTC).strftime("%Y/%m%d/%H%M")
             basename = str(time.time()) + ".fa.bgz"
             relpath = os.path.join(reldir, basename)
 

--- a/src/biocommons/seqrepo/fastadir/fastadir.py
+++ b/src/biocommons/seqrepo/fastadir/fastadir.py
@@ -194,7 +194,7 @@ class FastaDir(BaseReader, BaseWriter):
         #       <------ dir_ ----->
         #       <----------- path ----------->
         if self._writing is None:
-            reldir = datetime.datetime.now(datetime.UTC).strftime("%Y/%m%d/%H%M")
+            reldir = datetime.datetime.now(datetime.timezone.utc).strftime("%Y/%m%d/%H%M")
             basename = str(time.time()) + ".fa.bgz"
             relpath = os.path.join(reldir, basename)
 

--- a/src/biocommons/seqrepo/seqaliasdb/seqaliasdb.py
+++ b/src/biocommons/seqrepo/seqaliasdb/seqaliasdb.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import sqlite3
 from importlib import resources
@@ -20,6 +21,9 @@ if sqlite3.sqlite_version_info < min_sqlite_version_info:  # pragma: no cover
         __package__, min_sqlite_version, sqlite3.sqlite_version
     )
     raise ImportError(msg)
+
+
+sqlite3.register_converter("timestamp", lambda val: datetime.datetime.fromisoformat(val.decode()))
 
 
 class SeqAliasDB(object):


### PR DESCRIPTION
close #127 

* remove two cases of timezone-related deprecations -- one regarding default sqlite3 management of time type conversions back into python, and another from the `utcnow()` method

I'd appreciate some input about where to register the sqlite3 timestamp converter -- I put it in `seqaliasdb.py` since that seems like the place where it's most important to be pulling out precisely formatted strings but wasn't totally sure. It's sort of weird that the sqlite3 module has you register these things to some global context (?) rather than individual connections.