### PR TITLE
build!: move ipython/repl functionality to optional dependency group

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,17 +111,17 @@ tested. Patches to get other systems working would be welcomed.
 
 ### OS X
 
-    $ brew install python libpq
+    brew install python libpq
 
 ### Ubuntu
 
-    $ sudo apt install -y python3-dev gcc zlib1g-dev tabix
+    sudo apt install -y python3-dev gcc zlib1g-dev tabix
 
 ### All platforms
 
     $ python -m venv venv
     $ source venv/bin/activate
-    $ pip install seqrepo
+    $ pip install biocommons.seqrepo
     $ sudo mkdir -p /usr/local/share/seqrepo
     $ sudo chown $USER /usr/local/share/seqrepo
     $ seqrepo pull -i 2018-11-26
@@ -138,7 +138,9 @@ tested. Patches to get other systems working would be welcomed.
     >> sr["NC_000001.11"][780000:780020]
     'TGGTGGCACGCGCTTGTAGT'
 
-    # Or, use the seqrepo shell for even easier access
+    # Optional: Install with the `shell` dependency group
+    # (i.e., `pip install biocommons.seqrepo[shell]`)
+    # and use the seqrepo shell
     $ seqrepo start-shell -i 2018-11-26
     In [1]: sr["NC_000001.11"][780000:780020]
     Out[1]: 'TGGTGGCACGCGCTTGTAGT'
@@ -198,7 +200,7 @@ Install pre-commit hook:
 
 ## Building a docker image
 
-Docker images are available at https://hub.docker.com/r/biocommons/seqrepo.
+Docker images are available at <https://hub.docker.com/r/biocommons/seqrepo>.
 Tags correspond to the version of data, not the version of seqrepo, because the
 intent is to make it easy to depend on a local version of seqrepo *files*.  Each
 docker image is an installation of seqrepo that downloads the corresponding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-shell = [
-    "ipython ~= 8.4",
-]
+shell = ["ipython ~= 8.4"]
 dev = [
     "bandit ~= 1.7",
     "black ~= 22.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dynamic = ["version"]
 dependencies = [
     "bioutils > 0.4",
     "coloredlogs ~= 15.0",
-    "ipython ~= 8.4",
     "pysam ~= 0.22",
     "requests ~= 2.31",
     "six ~= 1.16",
@@ -28,12 +27,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+shell = [
+    "ipython ~= 8.4",
+]
 dev = [
     "bandit ~= 1.7",
     "black ~= 22.3",
     "build ~= 0.8",
     "flake8 ~= 4.0",
-    "ipython ~= 8.4",
     "isort ~= 5.10",
     "mypy-extensions ~= 1.0",
     "pre-commit ~= 3.4",

--- a/src/biocommons/seqrepo/cli.py
+++ b/src/biocommons/seqrepo/cli.py
@@ -684,7 +684,11 @@ def snapshot(opts: argparse.Namespace) -> None:
 def start_shell(opts: argparse.Namespace) -> None:
     seqrepo_dir = os.path.join(opts.root_directory, opts.instance_name)
     sr = SeqRepo(seqrepo_dir)  # noqa: 682
-    import IPython
+    try:
+        import IPython
+    except ImportError as e:
+        msg = "Unable to import IPython to start SeqRepo shell. Is the `shell` dependency group installed?"  # noqa: E501
+        raise ImportError(msg) from e
 
     IPython.embed(
         header="\n".join(


### PR DESCRIPTION
close #147 

Per brief discussion on a biocommons call the other day -- this PR moves the dependency (ipython) required for shell functionality to an optional group and adds a bit of information to the ImportError if ipython is unavailable.

I would expect this to impact a pretty small number of users, but it is a breaking change.