### PR TITLE
chore: remove unused YAPF config

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,6 +1,0 @@
-[style]
-based_on_style = pep8
-column_limit = 120
-spaces_before_comment = 4
-split_before_logical_operator = True
-split_before_named_assigns = True


### PR DESCRIPTION
Probably my bad for not removing this during the switch to Ruff earlier. This PR deletes an unused YAPF config file.