### PR TITLE
build: update yoyo, setuptools pin no longer needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ dependencies = [
     "pysam ~= 0.22",
     "requests ~= 2.31",
     "tqdm ~= 4.66",
-    "yoyo-migrations ~= 8.2",
-    "setuptools",  # pin until yoyo-migrations doesn't use pkg_resources
+    "yoyo-migrations ~= 9.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
We had previously pinned `setuptools` for 3.12 compatibility because `yoyo-migrations` made use of a deprecated feature. They're released a fix, so we can remove the pin now.