### PR TITLE
176 resolve testing warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pysam ~= 0.22",
     "requests ~= 2.31",
     "tqdm ~= 4.66",
-    "yoyo-migrations ~= 8.2",
+    "yoyo-migrations ~= 9.0",
     "setuptools",  # pin until yoyo-migrations doesn't use pkg_resources
 ]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,6 +17,9 @@ testpaths = src tests
 # show warnings
 filterwarnings =
     default
+    # yoyo/backends/base.py:411: DeprecationWarning: The default datetime adapter is deprecated as of Python 3.12
+    # As of 2025-03-02, there is no fix in yoyo
+    ignore:The default datetime adapter is deprecated
 
 markers =
   network


### PR DESCRIPTION
This PR hides (not resolves) warnings from yoyo-migrations.

The sqlite3 module has historically provided a mechanism to convert Python types to sqlite3 types. That mechanism is deprecated in Python 3.12, with warnings. Yoyo relies on that mechanism and has not been updated yet. For now, we'll hide the warnings so that we can see new warnings that may arise.
