### PR TITLE
switch deploy to use trusted publisher rather than token/password

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -108,4 +108,4 @@ jobs:
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        attestations: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -105,7 +105,6 @@ jobs:
       run: python -m build
 
     - name: Publish package
+      # Depends on trusted publishing configuration at pypi
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        attestations: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -73,10 +73,17 @@ jobs:
         make test
 
   deploy:
+    # See https://github.com/pypa/gh-action-pypi-publish/tree/release/v1?tab=readme-ov-file#usage
     needs:
     # - cqa
     - test
     runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/biocommons.seqrepo
+    permissions:
+      id-token: write  # mandatory for trusted publishing
 
     steps:
     - name: Environment
@@ -104,7 +111,7 @@ jobs:
     - name: Build package
       run: python -m build
 
-    - name: Publish package
+    - name: Upload release to PyPI
       # Depends on trusted publishing configuration at pypi
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
When attempting to release 0.6.10, github actions deploy to pypi failed with this:

```
Digest: sha256:95f6a263932ad985f1b29df33a1748fddb8b92b46b7c95a2a3b3c6c7506096a3
Status: Downloaded newer image for ghcr.io/pypa/gh-action-pypi-publish:release-v1
Warning: The workflow was run with the 'attestations: true' input, but an explicit password was also set, disabling Trusted Publishing. As a result, the attestations input is ignored.
Warning: Trusted Publishers allows publishing packages to PyPI from automated environments like GitHub Actions without needing to use username/password combinations or API tokens to authenticate with PyPI. Read more: https://docs.pypi.org/trusted-publishers
Warning: A new Trusted Publisher for the currently running publishing workflow can be created by accessing the following link(s) while logged-in as an owner of the package(s):
- https://pypi.org/manage/project/biocommons-seqrepo/settings/publishing/?provider=github&owner=biocommons&repository=biocommons.seqrepo&workflow_filename=python-package.yml

Checking dist/biocommons.seqrepo-0.6.10-py3-none-any.whl: PASSED
Checking dist/biocommons_seqrepo-0.6.10.tar.gz: PASSED
Uploading distributions to https://upload.pypi.org/legacy/
Uploading biocommons.seqrepo-0.6.10-py3-none-any.whl
WARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/          
         Invalid or non-existent authentication information. See                
         https://pypi.org/help/#invalid-auth for more information.       
```