### PR TITLE
build: require typing_extensions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        make develop
+        python -m pip install ".[tests]"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,10 +17,10 @@ jobs:
         cache: pip
         cache-dependency-path: '**/setup.cfg'
 
-    - name: Install test dependencies
+    - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --use-deprecated=legacy-resolver -e .[dev]
+        pip install --use-deprecated=legacy-resolver '.[dev]'
 
     - name: Lint with flake8
       run: |
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ".[tests]"
+        pip install --use-deprecated=legacy-resolver '.[tests]'
 
     - name: Test with pytest
       run: |

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ${VE_DIR}:
 #=> develop: install package in develop mode
 .PHONY: develop
 develop:
-	pip install -e .[dev]
+	pip install -e .[dev,tests]
 	pre-commit install
 
 #=> install: install package

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ${VE_DIR}:
 #=> develop: install package in develop mode
 .PHONY: develop
 develop:
-	pip install -e .[dev,tests]
+	pip install -e ".[dev,tests]"
 	pre-commit install
 
 #=> install: install package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pysam ~= 0.22",
     "requests ~= 2.31",
     "tqdm ~= 4.66",
-    # "typing_extensions",
+    "typing_extensions",
     "yoyo-migrations ~= 9.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pysam ~= 0.22",
     "requests ~= 2.31",
     "tqdm ~= 4.66",
+    # "typing_extensions",
     "yoyo-migrations ~= 9.0",
 ]
 
@@ -36,14 +37,16 @@ dev = [
     "mypy-extensions ~= 1.0",
     "pre-commit ~= 3.4",
     "pylint ~= 2.14",
-    "pytest-cov ~= 4.1",
-    "pytest-optional-tests",
-    "pytest ~= 7.1",
     "pyright~=1.1",
     "requests_html ~= 0.10",
     "ruff == 0.4.4",
-    "tox ~= 3.25",
     "vcrpy",
+]
+tests = [
+    "tox ~= 3.25",
+    "pytest-cov ~= 4.1",
+    "pytest-optional-tests",
+    "pytest ~= 7.1",
 ]
 docs = ["mkdocs"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,13 @@ dev = [
     "pyright~=1.1",
     "requests_html ~= 0.10",
     "ruff == 0.4.4",
-    "vcrpy",
 ]
 tests = [
     "tox ~= 3.25",
     "pytest-cov ~= 4.1",
     "pytest-optional-tests",
     "pytest ~= 7.1",
+    "vcrpy",
 ]
 docs = ["mkdocs"]
 


### PR DESCRIPTION
* ensure explicit dependency is available
* move testing-related dependencies out of `dev` group and only install them during the `test` job so that the error in #181 would've been caught: https://github.com/biocommons/biocommons.seqrepo/actions/runs/13936166604/job/39004394961