### PR TITLE
build: move ipython/repl functionality to optional dependency group

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ tested. Patches to get other systems working would be welcomed.
 
     $ python -m venv venv
     $ source venv/bin/activate
-    $ pip install seqrepo
+    $ pip install biocommons.seqrepo
     $ sudo mkdir -p /usr/local/share/seqrepo
     $ sudo chown $USER /usr/local/share/seqrepo
     $ seqrepo pull -i 2018-11-26
@@ -140,7 +140,9 @@ tested. Patches to get other systems working would be welcomed.
     >> sr["NC_000001.11"][780000:780020]
     'TGGTGGCACGCGCTTGTAGT'
 
-    # Or, use the seqrepo shell for even easier access
+    # Optional: Install with the `shell` dependency group
+    # and use the seqrepo shell
+    $ pip install "biocommons.seqrepo[shell]"
     $ seqrepo start-shell -i 2018-11-26
     In [1]: sr["NC_000001.11"][780000:780020]
     Out[1]: 'TGGTGGCACGCGCTTGTAGT'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dynamic = ["version"]
 dependencies = [
     "bioutils > 0.4",
     "coloredlogs ~= 15.0",
-    "ipython ~= 8.4",
     "pysam ~= 0.22",
     "requests ~= 2.31",
     "tqdm ~= 4.66",
@@ -28,6 +27,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+shell = [
+    "ipython ~= 8.4",
+]
 dev = [
     "bandit ~= 1.7",
     "build ~= 0.8",

--- a/src/biocommons/seqrepo/cli.py
+++ b/src/biocommons/seqrepo/cli.py
@@ -708,7 +708,11 @@ def snapshot(opts: argparse.Namespace) -> None:
 def start_shell(opts: argparse.Namespace) -> None:
     seqrepo_dir = os.path.join(opts.root_directory, opts.instance_name)
     sr = SeqRepo(seqrepo_dir)  # noqa: 682
-    import IPython
+    try:
+        import IPython
+    except ImportError as e:
+        msg = "Unable to import IPython to start SeqRepo shell. Is the `shell` dependency group installed?"  # noqa: E501
+        raise ImportError(msg) from e
 
     IPython.embed(
         header="\n".join(


### PR DESCRIPTION
Not sure what happened here, but this was approved and merged in https://github.com/biocommons/biocommons.seqrepo/pull/163 but seems to have fallen out of the main branch.