### PR TITLE
unpin developer tools in order to keep these up-to-date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .DS_Store
 .cache
 .coverage
+.coverage.*
 .eggs
 .idea
 .ipynb_checkpoints

--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,6 @@ build: %:
 #= TESTING
 # see test configuration in setup.cfg
 
-#=> cqa: execute code quality tests
-cqa:
-	flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
-	isort --profile black --check src
-	ruff format --check src tests
-	bandit -ll -r src
-
 #=> test: execute tests
 #=> test-code: test code (including embedded doctests)
 #=> test-docs: test example code in docs
@@ -107,14 +100,6 @@ reformat:
 
 ############################################################################
 #= UTILITY TARGETS
-
-#=> reformat: reformat code and commit
-.PHONY: reformat
-reformat:
-	@if ! git diff --cached --exit-code >/dev/null; then echo "Repository not clean" 1>&2; exit 1; fi
-	ruff src tests
-	isort src tests
-	git commit -a -m "reformatted with ruff and isort"
 
 #=> rename: rename files and substitute content for new repo name
 .PHONY: rename

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ tested. Patches to get other systems working would be welcomed.
 
 ### OS X
 
-    $ brew install python libpq
+    $ brew install python htslib
 
 ### Ubuntu
 
@@ -174,7 +174,7 @@ will greatly increase performance of sequence retrieval.
 
 ### Developing on OS X
 
-    brew install python libpq bash
+    brew install python htslib
 
 If you get "xcrun: error: invalid active developer path", you need to install
 XCode. See this [StackOverflow answer](https://apple.stackexchange.com/questions/254380/why-am-i-getting-an-invalid-active-developer-path-when-attempting-to-use-git-a).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,17 +29,16 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "bandit ~= 1.7",
-    "build ~= 0.8",
-    "flake8 ~= 4.0",
-    "ipython ~= 8.4",
-    "isort ~= 5.10",
-    "mypy-extensions ~= 1.0",
-    "pre-commit ~= 3.4",
-    "pylint ~= 2.14",
-    "pyright~=1.1",
-    "requests_html ~= 0.10",
-    "ruff == 0.4.4",
+    "bandit",
+    "build",
+    "flake8",
+    "ipython",
+    "isort",
+    "mypy-extensions",
+    "pre-commit",
+    "pylint",
+    "pyright",
+    "ruff",
 ]
 tests = [
     "tox ~= 3.25",


### PR DESCRIPTION
I chose to unpin developer tools because the frustration of having these fail due to staleness is likely more common and severe than having them fail due to newness.