### PR TITLE
186 rsync issues on mac again

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,31 +15,28 @@ jobs:
       with:
         python-version: "3.10"
         cache: pip
-        cache-dependency-path: '**/setup.cfg'
+        cache-dependency-path: '**/pyproject.toml'
 
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --use-deprecated=legacy-resolver '.[dev]'
+        pip install '.[dev]'
 
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
+        make cqa-flake8
+        
     - name: Format check with isort
       run: |
-        isort --check src
+        make cqa-isort
 
     - name: Format check with ruff
       run: |
-        ruff format --check src
+        make cqa-ruff-format
 
     - name: Security check with bandit
       run: |
-        bandit -ll -r src
+        make cqa-bandit
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,24 @@
+# All hooks use makefile targets in order to ensure
+# consistency with command line and git workflows
 repos:
 - repo: local
   hooks:
     -  id: flake8
        name: flake8
-       entry: flake8
+       entry: make cqa-flake8
        language: system
        types: [python]
     -  id: pyright
        name: pyright
-       entry: pyright
+       entry: make cqa-pyright
        language: system
        types: [python]
     -  id: isort
        name: isort
-       entry: isort
+       entry: make cqa-isort
        language: system
        types: [python]
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.4
-  hooks:
     - id: ruff-format
-      args: [ --check ]
+      name: ruff format
+      entry: make cqa-ruff-format
+      language: system

--- a/Makefile
+++ b/Makefile
@@ -86,12 +86,21 @@ tox:
 	tox
 
 #=> cqa: execute code quality tests
-cqa:
-	flake8 src --show-source --statistics
-	pyright
-	isort --check src --profile black
+cqa: cqa-flake8 cqa-pyright cqa-isort cqa-ruff-format cqa-bandit
+cqa-flake8:
+	# stop the build if there are Python syntax errors or undefined names
+	flake8 --count --select=E9,F63,F7,F82 --show-source --statistics src
+	# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+	flake8 --count --exit-zero --max-complexity=10 --statistics src
+cqa-pyright:
+	pyright src
+cqa-isort:
+	isort --check --profile black src
+cqa-ruff-format:
 	ruff format --check src
+cqa-bandit:
 	bandit -ll -r src
+
 
 #=> reformat: reformat code
 .PHONY: reformat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,16 +29,16 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "bandit",
-    "build",
-    "flake8",
-    "ipython",
-    "isort",
-    "mypy-extensions",
-    "pre-commit",
-    "pylint",
-    "pyright",
-    "ruff",
+    "bandit > 1.8",
+    "build > 0.10",
+    "flake8 > 7.2",
+    "ipython > 8.33",
+    "isort > 5.13",
+    "mypy-extensions > 1.0",
+    "pre-commit > 3.8",
+    "pylint > 2.17",
+    "pyright > 1.1",
+    "ruff > 0.11",
 ]
 tests = [
     "tox ~= 3.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,16 +29,16 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "bandit > 1.8",
-    "build > 0.10",
-    "flake8 > 7.2",
-    "ipython > 8.33",
-    "isort > 5.13",
-    "mypy-extensions > 1.0",
-    "pre-commit > 3.8",
-    "pylint > 2.17",
-    "pyright > 1.1",
-    "ruff > 0.11",
+    "bandit >= 1.8",
+    "build >= 0.10",
+    "flake8 >= 7.2",
+    "ipython >= 8.33",
+    "isort >= 5.13",
+    "mypy-extensions >= 1.0",
+    "pre-commit >= 3.8",
+    "pylint >= 2.17",
+    "pyright >= 1.1",
+    "ruff >= 0.11",
 ]
 tests = [
     "tox ~= 3.25",

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup(use_scm_version=True)

--- a/src/biocommons/seqrepo/cli.py
+++ b/src/biocommons/seqrepo/cli.py
@@ -38,6 +38,7 @@ SEQREPO_ROOT_DIR = os.environ.get("SEQREPO_ROOT_DIR", "/usr/local/share/seqrepo"
 DEFAULT_INSTANCE_NAME_RW = "master"
 DEFAULT_INSTANCE_NAME_RO = "latest"
 
+
 instance_name_new_re = re.compile(
     r"^20[12]\d-\d\d-\d\d$"
 )  # smells like a new datestamp, 2017-01-17
@@ -49,10 +50,6 @@ instance_name_re = re.compile(
 _logger = logging.getLogger(__name__)
 
 
-class RsyncExeError(Exception):
-    """Raise for issues relating to rsync executable."""
-
-
 def _check_rsync_binary(opts: argparse.Namespace) -> None:
     """Check for rsync vs openrsync binary issue
 
@@ -62,14 +59,22 @@ def _check_rsync_binary(opts: argparse.Namespace) -> None:
     :param opts: CLI args
     :raise RsyncExeError: if provided binary appears to be openrsync not rsync
     """
-    result = subprocess.check_output([opts.rsync_exe, "--version"])
-    if result is not None and ("openrsync" in result.decode()):
-        msg = f"Binary located at {opts.rsync_exe} appears to be an `openrsync` instance, but the SeqRepo CLI requires `rsync` (NOT `openrsync`). Please install `rsync` and manually provide its location with the `--rsync-exe` option. See README for more information."  # noqa: E501
-        raise RsyncExeError(msg)
+    if not opts.rsync_exe.startswith("/"):
+        opts.rsync_exe = shutil.which(opts.rsync_exe)
+        _logger.info(f"Found rsync at {opts.rsync_exe}")
+    cmd = [opts.rsync_exe, "--version"]
+    result = subprocess.run(cmd, capture_output=True)
+    result.check_returncode()
+    if result.stdout.decode().startswith("openrsync"):
+        raise RuntimeError(
+            "openrsync (at {opts.rsync_exe}) is not supported; "
+            "on mac, consider `brew install rsync`"
+        )
 
 
 def _get_remote_instances(opts: argparse.Namespace) -> list[str]:
     line_re = re.compile(r"d[-rwx]{9}\s+[\d,]+ \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} (.+)")
+    _check_rsync_binary(opts)
     rsync_cmd = [
         opts.rsync_exe,
         "--no-motd",
@@ -103,7 +108,7 @@ def parse_arguments() -> argparse.Namespace:
         "See https://github.com/biocommons/biocommons.seqrepo for more information"
     )
     top_p = argparse.ArgumentParser(
-        description=__doc__.split("\n\n")[0],
+        description=(__doc__ or "no description").split("\n\n")[0],
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         epilog=epilog,
     )
@@ -115,7 +120,9 @@ def parse_arguments() -> argparse.Namespace:
         default=SEQREPO_ROOT_DIR,
         help="seqrepo root directory (SEQREPO_ROOT_DIR)",
     )
-    top_p.add_argument("--rsync-exe", default="/usr/bin/rsync", help="path to rsync executable")
+    top_p.add_argument(
+        "--rsync-exe", default="rsync", help="rsync executable; found in PATH if not absolute"
+    )
     top_p.add_argument(
         "--verbose",
         "-v",
@@ -583,6 +590,7 @@ def pull(opts: argparse.Namespace) -> None:
     tmp_dir = tempfile.mkdtemp(dir=opts.root_directory, prefix=instance_name + ".")
     os.rmdir(tmp_dir)  # let rsync create it the directory
 
+    _check_rsync_binary(opts)
     cmd = [opts.rsync_exe, "-rtHP", "--no-motd"]
     if local_instances:
         latest_local_instance = local_instances[-1]
@@ -643,7 +651,7 @@ def snapshot(opts: argparse.Namespace) -> None:
 
     if os.path.commonpath([src_dir, dst_dir]).startswith(src_dir):
         raise RuntimeError(
-            "Cannot nest seqrepo directories " "({} is within {})".format(dst_dir, src_dir)
+            "Cannot nest seqrepo directories ({} is within {})".format(dst_dir, src_dir)
         )
 
     if os.path.exists(dst_dir):
@@ -752,8 +760,6 @@ def update_latest(opts: argparse.Namespace, mri: Optional[str] = None) -> None:
 
 def main() -> None:
     opts = parse_arguments()
-    _check_rsync_binary(opts)
-
     verbose_log_level = (
         logging.WARN if opts.verbose == 0 else logging.INFO if opts.verbose == 1 else logging.DEBUG
     )

--- a/src/biocommons/seqrepo/cli.py
+++ b/src/biocommons/seqrepo/cli.py
@@ -408,7 +408,7 @@ def add_assembly_names(opts: argparse.Namespace) -> None:
         sr.commit()
 
 
-def export(opts: argparse.Namespace) -> None:
+def export(opts: argparse.Namespace) -> None:  # noqa: C901
     seqrepo_dir = os.path.join(opts.root_directory, opts.instance_name)
     sr = SeqRepo(seqrepo_dir)
 

--- a/src/biocommons/seqrepo/config.py
+++ b/src/biocommons/seqrepo/config.py
@@ -11,8 +11,7 @@ def parse_caching_env_var(env_name: str, env_default: str) -> Optional[int]:
         caching_env_var_int = int(caching_env_var)
     except ValueError:
         raise ValueError(
-            f"{env_name} must be a valid int, none, or not set, "
-            "currently it is " + caching_env_var
+            f"{env_name} must be a valid int, none, or not set, currently it is " + caching_env_var
         )
     return caching_env_var_int
 

--- a/src/biocommons/seqrepo/fastadir/fastadir.py
+++ b/src/biocommons/seqrepo/fastadir/fastadir.py
@@ -236,7 +236,7 @@ class FastaDir(BaseReader, BaseWriter):
         backend.apply_migrations(migrations_to_apply)
 
     def _dump_aliases(self) -> None:
-        import prettytable
+        import prettytable  # type: ignore
 
         fields = "seq_id len alpha added relpath".split()
         pt = prettytable.PrettyTable(field_names=fields)

--- a/src/biocommons/seqrepo/seqaliasdb/seqaliasdb.py
+++ b/src/biocommons/seqrepo/seqaliasdb/seqaliasdb.py
@@ -57,7 +57,7 @@ class SeqAliasDB(object):
         # if we're not at the expected schema version for this code, bail
         if schema_version != expected_schema_version:  # pragma: no cover
             raise RuntimeError(
-                "Upgrade required: Database schema" "version is {} and code expects {}".format(
+                "Upgrade required: Database schemaversion is {} and code expects {}".format(
                     schema_version, expected_schema_version
                 )
             )
@@ -227,7 +227,7 @@ class SeqAliasDB(object):
     # Internal methods
 
     def _dump_aliases(self) -> None:  # pragma: no cover
-        import prettytable
+        import prettytable  # type: ignore
 
         cursor = self._db.cursor()
         fields = "seqalias_id seq_id namespace alias added is_current".split()
@@ -251,8 +251,8 @@ class SeqAliasDB(object):
             raise ImportError(msg)
         migration_dir = str(resources.files(__package__) / migration_path)
         migrations = yoyo.read_migrations(migration_dir)
-        assert (
-            len(migrations) > 0
-        ), f"no migration scripts found -- wrong migration path for {__package__}"
+        assert len(migrations) > 0, (
+            f"no migration scripts found -- wrong migration path for {__package__}"
+        )
         migrations_to_apply = backend.to_apply(migrations)
         backend.apply_migrations(migrations_to_apply)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 import io
 import os
 import tempfile
+from typing import List, Optional
 
 import pytest
 
@@ -12,18 +13,41 @@ from biocommons.seqrepo.utils import parse_defline
 
 @pytest.fixture
 def opts():
-    class MockOpts(object):
-        pass
+    class MockOpts:
+        def __init__(
+            self,
+            root_directory: Optional[str] = None,
+            fasta_files: Optional[List[str]] = None,
+            namespace: Optional[str] = None,
+            instance_name: Optional[str] = None,
+            verbose: int = 0,
+        ):
+            """
+            Mock class for options used in seqrepo tests.
+
+            Args:
+                root_directory: The root directory for the seqrepo instance.
+                fasta_files: List of FASTA file paths.
+                namespace: The namespace.
+                instance_name: The instance name.
+                verbose: Verbosity level.
+            """
+            self.root_directory = root_directory
+            self.fasta_files = fasta_files
+            self.namespace = namespace
+            self.instance_name = instance_name
+            self.verbose = verbose
 
     test_dir = os.path.dirname(__file__)
     test_data_dir = os.path.join(test_dir, "data")
 
-    opts = MockOpts()
-    opts.root_directory = os.path.join(tempfile.mkdtemp(prefix="seqrepo_pytest_"), "seqrepo")
-    opts.fasta_files = [os.path.join(test_data_dir, "sequences.fa.gz")]
-    opts.namespace = "test"
-    opts.instance_name = "test"
-    opts.verbose = 0
+    opts = MockOpts(
+        root_directory=os.path.join(tempfile.mkdtemp(prefix="seqrepo_pytest_"), "seqrepo"),
+        fasta_files=[os.path.join(test_data_dir, "sequences.fa.gz")],
+        namespace="test",
+        instance_name="test",
+        verbose=0,
+    )
     return opts
 
 

--- a/tests/test_fastadir.py
+++ b/tests/test_fastadir.py
@@ -45,7 +45,7 @@ def test_schema_version():
     orig_schema_version = FastaDir.schema_version
 
     with pytest.raises(RuntimeError):
-        FastaDir.schema_version = lambda x: -1
+        FastaDir.schema_version = lambda self: -1
         fd = FastaDir(tmpdir, writeable=True)
 
     FastaDir.schema_version = orig_schema_version

--- a/tests/test_seqrepo.py
+++ b/tests/test_seqrepo.py
@@ -121,15 +121,15 @@ def test_namespace_translation(tmpdir_factory):
 
 
 def test_translation(seqrepo):
-    assert "MD5:8b2698fb0b0c93558a6adbb11edb1e4b" in seqrepo.translate_identifier(
-        "en:rose"
-    ), "failed fully-qualified identifier lookup"
-    assert "MD5:8b2698fb0b0c93558a6adbb11edb1e4b" in seqrepo.translate_identifier(
-        "rose"
-    ), "failed unqualified identifier lookup"
-    assert "VMC:GS_bsoUMlD3TrEtlh9Dt1iT29mzfkwwFUDr" in seqrepo.translate_identifier(
-        "en:rose"
-    ), "failed to find expected identifier in returned identifiers"
+    assert "MD5:8b2698fb0b0c93558a6adbb11edb1e4b" in seqrepo.translate_identifier("en:rose"), (
+        "failed fully-qualified identifier lookup"
+    )
+    assert "MD5:8b2698fb0b0c93558a6adbb11edb1e4b" in seqrepo.translate_identifier("rose"), (
+        "failed unqualified identifier lookup"
+    )
+    assert "VMC:GS_bsoUMlD3TrEtlh9Dt1iT29mzfkwwFUDr" in seqrepo.translate_identifier("en:rose"), (
+        "failed to find expected identifier in returned identifiers"
+    )
     assert ["VMC:GS_bsoUMlD3TrEtlh9Dt1iT29mzfkwwFUDr"] == seqrepo.translate_identifier(
         "en:rose", target_namespaces=["VMC"]
     ), "failed to rerieve exactly the expected identifier"


### PR DESCRIPTION
Minor improvements (IMO) to rsync handling on mac, including:

- use standard exceptions
- find rsync in PATH rather than hardcoding (but allow for absolute path --rsync-exe argument)
- test for openrsync more affirmatively

In the course of doing this, I had to address some organic growth and skew between Makefile, pre-commit, and github workflows.

