### PR TITLE
update build tooling and package versions in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,17 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "bioutils > 0.4",
-    "coloredlogs ~= 15.0",
-    "ipython ~= 8.4",
-    "pysam ~= 0.22",
-    "requests ~= 2.31",
-    "tqdm ~= 4.66",
+    "bioutils >= 0.6",
+    "coloredlogs >= 15.0",
+    "pysam >= 0.23",
+    "requests >= 2.32",
+    "tqdm >= 4.67",
     "typing_extensions",
-    "yoyo-migrations ~= 9.0",
+    "yoyo-migrations >= 9.0",
 ]
 
 [project.optional-dependencies]
+shell = ["ipython >= 8.33"]
 dev = [
     "bandit >= 1.8",
     "build >= 0.10",
@@ -41,11 +41,11 @@ dev = [
     "ruff >= 0.11",
 ]
 tests = [
-    "tox ~= 3.25",
-    "pytest-cov ~= 4.1",
-    "pytest-optional-tests",
-    "pytest ~= 7.1",
-    "vcrpy",
+    "tox >= 3.28",
+    "pytest-cov >= 6.1",
+    "pytest-optional-tests >= 0.1",
+    "pytest >= 7.1",
+    "vcrpy >= 7.0",
 ]
 docs = ["mkdocs"]
 
@@ -57,7 +57,7 @@ seqrepo = "biocommons.seqrepo.cli:main"
 "Bug Tracker" = "https://github.com/biocommons/biocommons.seqrepo/issues"
 
 [build-system]
-requires = ["setuptools ~= 69.0", "setuptools_scm[toml] ~= 8.0"]
+requires = ["setuptools >= 75", "setuptools_scm[toml] >= 8"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
Previously in main:

```
> make build
⋮
Successfully built biocommons_seqrepo-0.6.12.dev4+g6ecc920.tar.gz and biocommons.seqrepo-0.6.12.dev4+g6ecc920-py3-none-any.whl
```

With this PR:
```
> make build
⋮
Successfully built biocommons_seqrepo-0.6.12.dev5+gdf09046.tar.gz and biocommons_seqrepo-0.6.12.dev5+gdf09046-py3-none-any.whl
```

Notice the wheel was previously `biocommons.seqrepo` and is now `biocommons_seqrepo`.
